### PR TITLE
feat: background image opacity change

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,18 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+input[type='range'] {
+  position: absolute;
+  height: 185px;
+  margin: 10px 0;
+  width: 45px;
+  top: 30%;
+  left: 10px;
+  -webkit-appearance: slider-vertical;
+  background-color: black; 
+  border: 1px solid #000000;
+  border-radius: 100px;
+  /* transform: rotate(270deg); */
+  z-index: 100;
+}

--- a/src/pages/DrawingPage.tsx
+++ b/src/pages/DrawingPage.tsx
@@ -54,6 +54,8 @@ function DrawingPage(): React.ReactElement {
   const [showWebCamModal, setShowWebCamModal] = useState(false);
   const closeWebCamModal = useCallback(() => setShowWebCamModal(false), []);
 
+  const [opacity, setOpacity] = useState<number>(0.5);
+
   const onSelectFile = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (e.target.files && e.target.files.length > 0) {
@@ -95,13 +97,29 @@ function DrawingPage(): React.ReactElement {
     }
   }, [isMobile, loadImage, setShowWebCamModal]);
 
+  const onChangeOpacity = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setOpacity(parseInt(e.target.value) / 100);
+    },
+    [setOpacity]
+  );
+
   return (
     <>
       <div className="fixed inset-0 flex flex-col">
-        <div
-          className="flex grow w-full bg-gray-200"
-          onPointerDown={closeSaveMode}
-        >
+        <div className="grow w-full bg-gray-200" onPointerDown={closeSaveMode}>
+          <div className="bg-black">
+            <input type="range" onChange={onChangeOpacity} />
+          </div>
+          {backImage && (
+            <div className="absolute">
+              <img
+                src={backImage}
+                alt="배경이미지"
+                style={{ opacity: opacity, width: '375px', height: '667px' }}
+              />
+            </div>
+          )}
           <CanvasDraw
             className="CanvasDraw"
             ref={(canvasDraw) => {
@@ -116,7 +134,6 @@ function DrawingPage(): React.ReactElement {
             lazyRadius={0}
             hideGrid
             hideInterface
-            imgSrc={backImage}
             enablePanAndZoom={true}
             mouseZoomFactor={1}
             zoomExtents={{ min: 0.33, max: 3 }}


### PR DESCRIPTION
CanvasDraw의 imgSrc에 넣으면 반투명 효과 적용시 매번 redrawing하면서 flickering이 생기기 때문에,
대신에 같은 사이즈의 img 태그에 넣어주었습니다.