### PR TITLE
fix: remove background image when navigate

### DIFF
--- a/src/pages/DrawingPage.tsx
+++ b/src/pages/DrawingPage.tsx
@@ -32,7 +32,7 @@ function DrawingPage(): React.ReactElement {
   const penColor = useRecoilValue(penColorState);
   const penWidth = useRecoilValue(penWidthState);
 
-  const backImage = useRecoilValue(backImageState);
+  const [backImage, setBackImg] = useRecoilState(backImageState);
   const [canvasRef, setCanvasRef] = useState<CanvasDraw | null>(null);
 
   const imageinput = useRef<HTMLInputElement>(null);
@@ -123,8 +123,9 @@ function DrawingPage(): React.ReactElement {
 
   const navigate = useNavigate();
   const moveBack = useCallback(() => {
+    setBackImg(null);
     navigate(-1);
-  }, [navigate]);
+  }, [navigate, setBackImg]);
 
   const complete = useCallback(() => {
     if (!canvasRef) return;


### PR DESCRIPTION
/draw에서 뒤로가기 눌렀을 때 background image 값을 null로 변경되게 했습니다.
'완료' -> /preview 갔다가 뒤로가기 했을 때도 선택해둔 back image를 제거해야할까요? 🤔